### PR TITLE
Add support for Windows x64

### DIFF
--- a/example/windows/flutter/CMakeLists.txt
+++ b/example/windows/flutter/CMakeLists.txt
@@ -91,6 +91,7 @@ add_custom_command(
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
       windows-x64 $<CONFIG>
+  VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS
   "${FLUTTER_LIBRARY}"

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -19,6 +19,13 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
 
 # List of absolute paths to libraries that should be bundled with the plugin
 set(web_gpu_bundled_libraries
-  ""
+  "${CMAKE_CURRENT_SOURCE_DIR}/bin/${MSVC_CXX_ARCHITECTURE_ID}/dawn_proc.dll"
+  "${CMAKE_CURRENT_SOURCE_DIR}/bin/${MSVC_CXX_ARCHITECTURE_ID}/dawn_native.dll"
   PARENT_SCOPE
 )
+
+target_include_directories(${PLUGIN_NAME} PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}/../third_party")
+target_link_directories(${PLUGIN_NAME} PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}/lib/${MSVC_CXX_ARCHITECTURE_ID}")
+target_link_libraries(${PLUGIN_NAME} PRIVATE dawn_proc.dll.lib dawn_native.dll.lib)

--- a/windows/web_gpu_plugin.cpp
+++ b/windows/web_gpu_plugin.cpp
@@ -3,16 +3,14 @@
 // This must be included before many other Windows headers.
 #include <windows.h>
 
-// For getPlatformVersion; remove unless needed for your plugin implementation.
-#include <VersionHelpers.h>
+#include <dawn/dawn_proc.h>
+#include <dawn_native/DawnNative.h>
 
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_windows.h>
 #include <flutter/standard_method_codec.h>
 
-#include <map>
 #include <memory>
-#include <sstream>
 
 namespace {
 
@@ -56,17 +54,9 @@ WebGpuPlugin::~WebGpuPlugin() {}
 void WebGpuPlugin::HandleMethodCall(
     const flutter::MethodCall<flutter::EncodableValue> &method_call,
     std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
-  if (method_call.method_name().compare("getPlatformVersion") == 0) {
-    std::ostringstream version_stream;
-    version_stream << "Windows ";
-    if (IsWindows10OrGreater()) {
-      version_stream << "10+";
-    } else if (IsWindows8OrGreater()) {
-      version_stream << "8";
-    } else if (IsWindows7OrGreater()) {
-      version_stream << "7";
-    }
-    result->Success(flutter::EncodableValue(version_stream.str()));
+  if (method_call.method_name().compare("init") == 0) {
+    dawnProcSetProcs(&dawn_native::GetProcs());
+    result->Success(flutter::EncodableValue(true));
   } else {
     result->NotImplemented();
   }


### PR DESCRIPTION
Prebuilt release libs from the latest Dawn main (commit sha1
86980018b3f2786aeb5ded1220ec94bc927fa6b2).

The integration test verifies that wgpuCreateInstance() call succeeds:

    web_gpu\example> flutter drive --driver=integration_test/driver.dart --target=integration_test/bindings_test.dart
    Running "flutter pub get" in example...                            484ms
    Building Windows application...
    VMServiceFlutterDriver: Connecting to Flutter application at http://127.0.0.1:63380/r2YdB3Zv0rI=/
    VMServiceFlutterDriver: Isolate found with number: 2330838795048395
    VMServiceFlutterDriver: Isolate is paused at start.
    VMServiceFlutterDriver: Attempting to resume isolate
    flutter: Test execution completed: {wgpuCreateInstance: Instance of 'Success'}
    VMServiceFlutterDriver: Connected to Flutter application.
    flutter: Warning: integration_test test plugin was not detected.
    All tests passed.