### PR TITLE
Replace the method channel with a helper library

### DIFF
--- a/example/integration_test/bindings_test.dart
+++ b/example/integration_test/bindings_test.dart
@@ -9,9 +9,9 @@ import 'package:web_gpu/web_gpu.dart';
 void main() => run(_testMain);
 
 void _testMain() async {
-  await WebGpu.ensureInitialized();
+  WebGpu.ensureInitialized();
 
-  test('wgpuCreateInstance', () async {
+  test('wgpuCreateInstance', () {
     final instance = dylib.wgpuCreateInstance(ffi.nullptr);
     expect(instance, isNotNull);
     expect(instance.address, isNonZero);

--- a/lib/src/dylib.dart
+++ b/lib/src/dylib.dart
@@ -29,7 +29,7 @@ String get _libSuffix {
           : '.so';
 }
 
-String _fixupLibName(String libName) {
+String fixupLibName(String libName) {
   return libName.prefixWith(_libPrefix).suffixWith(_libSuffix);
 }
 
@@ -40,17 +40,20 @@ bool _isFilePath(String path) {
       Directory(path).statSync().type == FileSystemEntityType.file;
 }
 
-String _resolveLibPath(String baseName, String environmentVariable) {
-  // allow specifying path to libdawn_proc.so via LIBDAWN_PATH Dart define or
-  // environment variable
-  final path = String.fromEnvironment(
-    environmentVariable,
-    defaultValue: Platform.environment[environmentVariable] ?? '',
-  );
+String _resolveLibPath(String baseName, [String environmentVariable = '']) {
+  var path = '';
+  if (environmentVariable.isNotEmpty) {
+    // allow specifying path to libdawn_proc.so via LIBDAWN_PATH Dart define or
+    // environment variable
+    final path = String.fromEnvironment(
+      environmentVariable,
+      defaultValue: Platform.environment[environmentVariable] ?? '',
+    );
 
-  // LIBDAWN_PATH=/path/to/libdawn_proc.so (full file path specified)
-  if (_isFilePath(path)) return path;
+    // LIBDAWN_PATH=/path/to/libdawn_proc.so (full file path specified)
+    if (_isFilePath(path)) return path;
+  }
 
   // LIBDAWN_PATH=/path (just the path specified)
-  return _fixupLibPath(path) + _fixupLibName(baseName);
+  return _fixupLibPath(path) + fixupLibName(baseName);
 }

--- a/lib/src/init.dart
+++ b/lib/src/init.dart
@@ -1,0 +1,15 @@
+import 'dart:ffi' as ffi;
+
+import 'dylib.dart';
+
+typedef _c_initWebGpu = ffi.Void Function();
+typedef _dart_initWebGpu = void Function();
+
+bool initWebGpu() {
+  final lib = ffi.DynamicLibrary.open(fixupLibName('web_gpu_init'));
+  final initFunc =
+      lib.lookupFunction<_c_initWebGpu, _dart_initWebGpu>('initWebGpu');
+  if (initFunc == null) return false;
+  initFunc();
+  return true;
+}

--- a/lib/web_gpu.dart
+++ b/lib/web_gpu.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:flutter/services.dart';
 
+import 'src/init.dart';
+
 class WebGpu {
   static const MethodChannel _channel = const MethodChannel('web_gpu');
   static bool _initialized = false;
@@ -11,8 +13,8 @@ class WebGpu {
     return version;
   }
 
-  static Future<void> ensureInitialized() async {
+  static void ensureInitialized() {
     if (_initialized) return;
-    _initialized = await _channel.invokeMethod('init');
+    _initialized = initWebGpu();
   }
 }

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -5,6 +5,7 @@ project(${PROJECT_NAME} LANGUAGES CXX)
 # This value is used when generating builds using this plugin, so it must
 # not be changed
 set(PLUGIN_NAME "web_gpu_plugin")
+set(LIB_NAME "web_gpu_init")
 
 add_library(${PLUGIN_NAME} SHARED
   "web_gpu_plugin.cc"
@@ -17,16 +18,22 @@ target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
 target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
+target_link_libraries(${PLUGIN_NAME} PRIVATE ${LIB_NAME})
+
+set(LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib/${CMAKE_SYSTEM_PROCESSOR}")
+
+add_library(${LIB_NAME} SHARED
+  "web_gpu_init.cc"
+)
+target_include_directories(${LIB_NAME} PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}/../third_party")
+target_link_directories(${LIB_NAME} PRIVATE ${LIB_DIR})
+target_link_libraries(${LIB_NAME} PRIVATE dawn_proc dawn_native)
 
 # List of absolute paths to libraries that should be bundled with the plugin
 set(web_gpu_bundled_libraries
-  "${CMAKE_CURRENT_SOURCE_DIR}/lib/${CMAKE_SYSTEM_PROCESSOR}/libdawn_proc.so"
-  "${CMAKE_CURRENT_SOURCE_DIR}/lib/${CMAKE_SYSTEM_PROCESSOR}/libdawn_native.so"
+  "$<TARGET_FILE:${LIB_NAME}>"
+  "${LIB_DIR}/libdawn_proc.so"
+  "${LIB_DIR}/libdawn_native.so"
   PARENT_SCOPE
 )
-
-target_include_directories(${PLUGIN_NAME} PRIVATE
-  "${CMAKE_CURRENT_SOURCE_DIR}/../third_party")
-target_link_directories(${PLUGIN_NAME} PRIVATE
-  "${CMAKE_CURRENT_SOURCE_DIR}/lib/${CMAKE_SYSTEM_PROCESSOR}")
-target_link_libraries(${PLUGIN_NAME} PRIVATE dawn_proc dawn_native)

--- a/linux/web_gpu_init.cc
+++ b/linux/web_gpu_init.cc
@@ -1,0 +1,10 @@
+#include <dawn/dawn_proc.h>
+#include <dawn_native/DawnNative.h>
+
+#define WEB_GPU_EXPORT __attribute__((visibility("default")))
+
+extern "C" {
+WEB_GPU_EXPORT void initWebGpu();
+}
+
+void initWebGpu() { dawnProcSetProcs(&dawn_native::GetProcs()); }

--- a/linux/web_gpu_plugin.cc
+++ b/linux/web_gpu_plugin.cc
@@ -1,7 +1,5 @@
 #include "include/web_gpu/web_gpu_plugin.h"
 
-#include <dawn/dawn_proc.h>
-#include <dawn_native/DawnNative.h>
 #include <flutter_linux/flutter_linux.h>
 
 #define WEB_GPU_PLUGIN(obj) \
@@ -21,7 +19,6 @@ static void web_gpu_plugin_handle_method_call(WebGpuPlugin* self,
   const gchar* method = fl_method_call_get_name(method_call);
 
   if (strcmp(method, "init") == 0) {
-    dawnProcSetProcs(&dawn_native::GetProcs());
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
   } else {
     response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -5,6 +5,7 @@ project(${PROJECT_NAME} LANGUAGES CXX)
 # This value is used when generating builds using this plugin, so it must
 # not be changed
 set(PLUGIN_NAME "web_gpu_plugin")
+set(LIB_NAME "web_gpu_init")
 
 add_library(${PLUGIN_NAME} SHARED
   "web_gpu_plugin.cpp"
@@ -16,16 +17,23 @@ target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
+target_link_libraries(${PLUGIN_NAME} PRIVATE ${LIB_NAME})
+
+set(BIN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/bin/${MSVC_CXX_ARCHITECTURE_ID}")
+set(LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib/${MSVC_CXX_ARCHITECTURE_ID}")
+
+add_library(${LIB_NAME} SHARED
+  "web_gpu_init.cpp"
+)
+target_include_directories(${LIB_NAME} PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}/../third_party")
+target_link_directories(${LIB_NAME} PRIVATE ${LIB_DIR})
+target_link_libraries(${LIB_NAME} PRIVATE dawn_proc.dll.lib dawn_native.dll.lib)
 
 # List of absolute paths to libraries that should be bundled with the plugin
 set(web_gpu_bundled_libraries
-  "${CMAKE_CURRENT_SOURCE_DIR}/bin/${MSVC_CXX_ARCHITECTURE_ID}/dawn_proc.dll"
-  "${CMAKE_CURRENT_SOURCE_DIR}/bin/${MSVC_CXX_ARCHITECTURE_ID}/dawn_native.dll"
+  "$<TARGET_FILE:${LIB_NAME}>"
+  "${BIN_DIR}/dawn_proc.dll"
+  "${BIN_DIR}/dawn_native.dll"
   PARENT_SCOPE
 )
-
-target_include_directories(${PLUGIN_NAME} PRIVATE
-  "${CMAKE_CURRENT_SOURCE_DIR}/../third_party")
-target_link_directories(${PLUGIN_NAME} PRIVATE
-  "${CMAKE_CURRENT_SOURCE_DIR}/lib/${MSVC_CXX_ARCHITECTURE_ID}")
-target_link_libraries(${PLUGIN_NAME} PRIVATE dawn_proc.dll.lib dawn_native.dll.lib)

--- a/windows/web_gpu_init.cpp
+++ b/windows/web_gpu_init.cpp
@@ -1,0 +1,10 @@
+#include <dawn/dawn_proc.h>
+#include <dawn_native/DawnNative.h>
+
+#define WEB_GPU_EXPORT __declspec(dllexport)
+
+extern "C" {
+WEB_GPU_EXPORT void initWebGpu();
+}
+
+void initWebGpu() { dawnProcSetProcs(&dawn_native::GetProcs()); }

--- a/windows/web_gpu_plugin.cpp
+++ b/windows/web_gpu_plugin.cpp
@@ -3,9 +3,6 @@
 // This must be included before many other Windows headers.
 #include <windows.h>
 
-#include <dawn/dawn_proc.h>
-#include <dawn_native/DawnNative.h>
-
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_windows.h>
 #include <flutter/standard_method_codec.h>
@@ -55,8 +52,7 @@ void WebGpuPlugin::HandleMethodCall(
     const flutter::MethodCall<flutter::EncodableValue> &method_call,
     std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
   if (method_call.method_name().compare("init") == 0) {
-    dawnProcSetProcs(&dawn_native::GetProcs());
-    result->Success(flutter::EncodableValue(true));
+    result->Success(flutter::EncodableValue(nullptr));
   } else {
     result->NotImplemented();
   }


### PR DESCRIPTION
libdawn_proc must be initialized in C++ with a proc table from
libdawn_native. For desktop platforms it was possible to call an
initialization routine in the platform plugin via method channel,
but the same approach wouldn't work for the rest of the platforms.